### PR TITLE
Python3: update to 3.9.12

### DIFF
--- a/packages/lang/Python3/package.mk
+++ b/packages/lang/Python3/package.mk
@@ -3,8 +3,8 @@
 
 PKG_NAME="Python3"
 # When changing PKG_VERSION remember to sync PKG_PYTHON_VERSION!
-PKG_VERSION="3.9.11"
-PKG_SHA256="66767a35309d724f370df9e503c172b4ee444f49d62b98bc4eca725123e26c49"
+PKG_VERSION="3.9.12"
+PKG_SHA256="2cd94b20670e4159c6d9ab57f91dbf255b97d8c1a1451d1c35f4ec1968adf971"
 PKG_LICENSE="OSS"
 PKG_SITE="https://www.python.org/"
 PKG_URL="https://www.python.org/ftp/python/${PKG_VERSION}/${PKG_NAME::-1}-${PKG_VERSION}.tar.xz"


### PR DESCRIPTION
release notes: https://www.python.org/downloads/release/python-3912/

This is a special release which fixes a regression introduced by BPO
46968 which caused Python to no longer build on Red Hat Enterprise Linux
6. There are only 12 other bugfixes on top of 3.9.11 in this release.